### PR TITLE
Change task statement editor from html to markdown

### DIFF
--- a/static/guides.js
+++ b/static/guides.js
@@ -1,9 +1,24 @@
+const task_statement_description = ["<p>Here you can design a task statement, please provide also a brief description on how the input and output is formatted. For example, an input can be a single number and output can be corresponding letter in English alphabet.</p>",
+"<p>Task title and example test description will be added automatically to the package.</p>",
+"<p>The editor uses easy to learn markdown markup.</p>",
+"<p>Use <strong title=\"Toggle Side by Side (F9)\" tabindex=\"-1\" class=\"fa fa-columns no-disable no-mobile active\" style=\"display: inline\"></strong> from toolbar to enter fullscreen view with preview of how the statement will look like for participants shown on the right.</p>",
+"<p>Use <strong title=\"Markdown Guide\" tabindex=\"-1\" class=\"fa fa-question-circle\" href=\"https://simplemde.com/markdown-guide\" target=\"_blank\"></strong> from toolbar to access markdown cheat sheet.</p>",
+"<p>Apart from standard markdown elements your task statement can include mathematical expressions (\\(\\LaTeX\\) syntax).</p>",
+"<p>For example:</p>",
+"<p>\\\\<i></i>(x\\\\) in task statement will turn into \\(x\\)</p>",
+"<p>\\\\<i></i>(a + 2 \\cdot 7 = 3\\\\) in the task statement will turn into \\(a + 2 \\cdot 7 = 3\\)</p>",
+"<p>\\\\<i></i>(b\\_{i + 2} \\cdot 12 + 7 = 3^{2+i}\\\\) in the task statement will turn into \\(b_{i + 2} \\cdot 12 + 7 = 3^{2+i}\\)</p>",
+"<p><strong>Note:</strong> unlike in \\(\\LaTeX\\) you need to prepend _ with \\ because _ has special meaning in markdown.</p>",
+"<p>\\\\<i></i>(\\frac{2}{3}\\\\) in the task statement will turn into \\(\\frac{2}{3}\\)</p>",
+"<p>\\\\<i></i>(1 \\leq n &lt; m \\leq 10^9\\\\) in the task statement will turn into \\(1 \\leq n &lt; m \\leq 10^9\\)</p>",
+"<p>You may also use $<i></i>$...$<i></i>$ or \\\\[...\\\\] delimiters instead of \\\\<i></i>(...\\\\) to make your equations appear on separate lines.</p>"].join('');
+
 const desc = {
     "tag-and-title": "First, design a title and a tag -- short version of title, 3-4 characters. For example title \"Bytesaurus adventures\" is a great title, and \"adv\" can be its corresponding tag.",
-    "task-statement" : "Here you can design a task statement, please provide also a brief description on how the input and output is formatted. For example, an input can be a single number and output can be corresponding letter in english alphabet.",
+    "task-statement" : task_statement_description,
     "sample-test" : "This test will be appended to task statement for students -- it will be presented as an example. It's crucial that example fits to input description. Corresponding input for previous examplanary task statement could be 3, and corresponding output could be c.",
     "correctness-tests" : "These tests won't be visible for your students. They will be used for grading their solutions, so it's good idea to put some edge cases here. In our example, possible edge case could be a number corresponding to first and last letter in alphabet."
-}
+};
 
 var testNum = 4;
 const testNumMax = 8;
@@ -24,7 +39,7 @@ $(document).ready(function () {
         element: $("#task-content")[0],
         // Spell checker works for english only, better to disable it.
         spellChecker: false,
-        placeholder: "Write your task statement here :-)",
+        placeholder: "Write your task statement here using markdown markup language :-)",
         previewRender: function(plainText, preview) {
 
             // MathJax can be ordered to parse any DOM element that changed and has new math elements.
@@ -79,6 +94,7 @@ $(document).ready(function () {
             '<div class="card-body"> ' +
             desc["task-statement"] +
             ' </div>');
+        MathJax.Hub.Queue(["Typeset", MathJax.Hub, "card-body"]);
     });
 
     $('#flush-collapseThree').on('show.bs.collapse', function () {

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <title>Minimal example</title>
-    <link href="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.css" rel="stylesheet">
     <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css"
           integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" rel="stylesheet">
     <link href="static/css/index.css" rel="stylesheet"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
 </head>
 <body>
@@ -54,11 +54,8 @@
                          id="flush-collapseTwo">
                         <div class="accordion-body">
                             <div class="col align-self-center">
-                                <div id="task-content">
-                                    <p>
-                                        Write the task statement here :-)
-                                    </p>
-                                </div>
+                                <textarea id="task-content"></textarea>
+                                <p id="mathjax-buffer" style="display:none;"></p>
                             </div>
                         </div>
                     </div>
@@ -131,11 +128,13 @@
 </div>
 
 <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-<script defer src="http://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.9/summernote.js"></script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 <script crossorigin="anonymous"
         integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW"
         src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js"></script>
 </body>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.js" integrity="sha512-ksSfTk6JIdsze75yZ8c+yDVLu09SNefa9IicxEE+HZvWo9kLPY1vrRlmucEMHQReWmEdKqusQWaDMpkTb3M2ug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="../static/guides.js"></script>
 
 </html>


### PR DESCRIPTION
Changes Summernote html editor to SimpleMDE markdown editor.
Adds some custom logic to add Mathjax support in the editor preview.
As markdown sometimes treats \ as escape character, latex delimiters are
different than usual (\\(...\\) is changed to \\\\(...\\\\), same with
\\[...\\]).